### PR TITLE
Update common-themebuilder-json-from-scss.md

### DIFF
--- a/knowledge-base/common-themebuilder-json-from-scss.md
+++ b/knowledge-base/common-themebuilder-json-from-scss.md
@@ -1,12 +1,12 @@
 ---
-title: Missing JSON file to Import in the ThemeBuilder
-description: The SASS Theme Builder requires a JSON file to import a theme. Here is how to create it if you don't have it.
+title: Importing SASS theme in ThemeBuilder
+description: The ThemeBuilder application requires a ZIP file to import a theme. Here is how to create it if you don't have it.
 type: troubleshooting
-page_title: JSON File for Theme Builder Import Unavailable
+page_title: ZIP File for Theme Builder Import Unavailable
 slug: common-kb-themebuilder-json-from-scss
 position: 
 tags: telerik, blazor, custom, theme, themebuilder
-ticketid: 1523785, 1521445, 1525713
+ticketid: 1523785, 1521445, 1525713, 1618579
 res_type: kb
 ---
 
@@ -15,223 +15,24 @@ res_type: kb
 	<tbody>
 		<tr>
 			<td>Product</td>
-			<td>UI for Blazor</td>
+			<td>UI for Blazor, ThemeBuilder</td>
 		</tr>
 	</tbody>
 </table>
 
 
 ## Description
-I have a custom theme `SCSS` (SASS) file with variables and values, which I created with the [SASS Theme Builder](https://themebuilder.telerik.com/blazor-ui). I want to import this `SCSS` file to the Theme Builder to make some changes, but the Theme Builder now requires a `JSON` file import.
 
-> Starting with R3 2022, ThemeBuilder is accessible from a [new URL](https://themebuilderapp.telerik.com). This new ThemeBuilder version replaces the [previous ThemeBuilder](https://themebuilder.telerik.com/) and provides more free features and also a Pro tier. All your existing custom themes will continue to work in the new ThemeBuilder.  
+I have a custom theme `SCSS` (SASS) or `JSON` file with variables and values, which I created with [the ThemeBuilder application](https://themebuilderapp.telerik.com). I want to import this `SCSS` file to the ThemeBuilder to make some changes, but the Theme Builder now requires a `ZIP` file import.
+
+> Starting with R3 2022, ThemeBuilder is accessible from a [new URL](https://themebuilderapp.telerik.com). This new ThemeBuilder version replaces the previous ThemeBuilder and provides more free features through its Pro, Ultimate, and Enterprise tiers. All your existing custom themes will continue to work in the new ThemeBuilder.  
 
 ## Cause\Possible Cause(s)
-The Theme Builder used to accept an `SCSS` (SASS) file to import an existing custom theme. This caused [some issues](https://github.com/telerik/kendo-themes/issues/2043) and we decided to switch to `JSON` import instead.
+
+Older versions of the ThemeBuilder applications were accepting `SCSS` (SASS) or `JSON` files to import an existing custom theme. Because this approach caused some issues, the team switched to the `ZIP` import instead.
 
 ## Suggested Workarounds
-If your custom theme targets specific components, we recommend that you [create it from scratch]({%slug themes-custom%}).
 
-If your custom theme targets all components, you can create the `JSON` file manually from the existing `SCSS` file. Here is how the JSON file should look like and the things you need to change:
+All themes created with ThemeBuilder must be migrated to the latest application version. Once the theme migrates to the latest version, you can make all needed modifications within the ThemeBuilder application. [Learn how to manually migrate a theme with ThemeBuilder Pro here ...](https://docs.telerik.com/themebuilder/web-app/migrating-projects)
 
-* `CUSTOM_NAME` - should be the name of your custom theme
-* `ORIGINAL_NAME` - should be the name of your base theme, e.g. `default`, `bootstrap`, `material`, etc.
-* all variable **values**
-
->tip The `"themeBuilder"` field has been replaced with a more generic one - `"groups"`. Make sure you use the updated syntax in your JSON file.
-
-```json
-{
-    "name": "CUSTOM_NAME",
-    "base": "@progress/kendo-theme-ORIGINAL_NAME",
-    "product": "kendo",
-    "components": [],
-    "groups": [
-        {
-            "name": "",
-            "variables": {
-                "border-radius": {
-                    "name": "Border radius",
-                    "type": "number",
-                    "value": "2px",
-                    "key": "border-radius"
-                },
-                "primary": {
-                    "name": "Primary",
-                    "type": "color",
-                    "value": "#fb00ff",
-                    "key": "primary"
-                },
-                "secondary": {
-                    "name": "Secondary",
-                    "type": "color",
-                    "value": "#f6f6f6",
-                    "key": "secondary"
-                },
-                "info": {
-                    "name": "Info",
-                    "type": "color",
-                    "value": "#3e80ed",
-                    "key": "info"
-                },
-                "success": {
-                    "name": "Success",
-                    "type": "color",
-                    "value": "#5ec232",
-                    "key": "success"
-                },
-                "warning": {
-                    "name": "Warning",
-                    "type": "color",
-                    "value": "#fdce3e",
-                    "key": "warning"
-                },
-                "error": {
-                    "name": "Error",
-                    "type": "color",
-                    "value": "#d51923",
-                    "key": "error"
-                },
-                "body-text": {
-                    "name": "Body text color",
-                    "type": "color",
-                    "value": "#424242",
-                    "key": "body-text"
-                },
-                "body-bg": {
-                    "name": "Body background",
-                    "type": "color",
-                    "value": "#ffffff",
-                    "key": "body-bg"
-                },
-                "headings-text": {
-                    "name": "Headings text color",
-                    "type": "color",
-                    "value": "#272727",
-                    "key": "headings-text"
-                },
-                "subtle-text": {
-                    "name": "Subtle text color",
-                    "type": "color",
-                    "value": "#666666",
-                    "key": "subtle-text"
-                },
-                "disabled-text": {
-                    "name": "Disabled text color",
-                    "type": "color",
-                    "value": "#8f8f8f",
-                    "key": "disabled-text"
-                },
-                "component-text": {
-                    "name": "Component text color",
-                    "type": "color",
-                    "value": "#0912b7",
-                    "key": "component-text"
-                },
-                "component-bg": {
-                    "name": "Component background",
-                    "type": "color",
-                    "value": "#ffffff",
-                    "key": "component-bg"
-                },
-                "base-text": {
-                    "name": "Header text color",
-                    "type": "color",
-                    "value": "#424242",
-                    "key": "base-text"
-                },
-                "base-bg": {
-                    "name": "Header background",
-                    "type": "color",
-                    "value": "#fafafa",
-                    "key": "base-bg"
-                },
-                "hovered-text": {
-                    "name": "Hover text color",
-                    "type": "color",
-                    "value": "#424242",
-                    "key": "hovered-text"
-                },
-                "hovered-bg": {
-                    "name": "Hover background",
-                    "type": "color",
-                    "value": "#ececec",
-                    "key": "hovered-bg"
-                },
-                "selected-text": {
-                    "name": "Selected text color",
-                    "type": "color",
-                    "value": "#ffffff",
-                    "key": "selected-text"
-                },
-                "selected-bg": {
-                    "name": "Selected background",
-                    "type": "color",
-                    "value": "#ff6358",
-                    "key": "selected-bg"
-                },
-                "button-text": {
-                    "name": "Button text color",
-                    "type": "color",
-                    "value": "#424242",
-                    "key": "button-text"
-                },
-                "button-bg": {
-                    "name": "Button background",
-                    "type": "color",
-                    "value": "#f5f5f5",
-                    "key": "button-bg"
-                },
-                "link-text": {
-                    "name": "Link text color",
-                    "type": "color",
-                    "value": "#32f800",
-                    "key": "link-text"
-                },
-                "link-hover-text": {
-                    "name": "Link hover text color",
-                    "type": "color",
-                    "value": "#d6534a",
-                    "key": "link-hover-text"
-                },
-                "series-a": {
-                    "name": "Series A",
-                    "type": "color",
-                    "value": "#ff6358",
-                    "key": "series-a"
-                },
-                "series-b": {
-                    "name": "Series B",
-                    "type": "color",
-                    "value": "#ffd246",
-                    "key": "series-b"
-                },
-                "series-c": {
-                    "name": "Series C",
-                    "type": "color",
-                    "value": "#78d237",
-                    "key": "series-c"
-                },
-                "series-d": {
-                    "name": "Series D",
-                    "type": "color",
-                    "value": "#28b4c8",
-                    "key": "series-d"
-                },
-                "series-e": {
-                    "name": "Series E",
-                    "type": "color",
-                    "value": "#2d73f5",
-                    "key": "series-e"
-                },
-                "series-f": {
-                    "name": "Series F",
-                    "type": "color",
-                    "value": "#aa46be",
-                    "key": "series-f"
-                }
-            }
-        }
-    ]
-}
-```
+The ThemeBuilder application, licensed with [the Ultimate and Enterprise tiers](https://www.telerik.com/themebuilder/pricing), provides the option for automatic migration of themes generated with older ThemeBuilder versions. Once the theme migrates to the latest version, you can make all needed modifications within the ThemeBuilder application. [Learn more about the automatic migration with ThemeBuilder Ultimate here...](https://docs.telerik.com/themebuilder/web-app/automatic-migrations)


### PR DESCRIPTION
The new version of ThemeBuilder no longer supports importing of `JSON` or `SCSS` files. Instead, it now uses ZIP files. The article is updated to point to our detailed guides for TB Pro (manual migration through generating ZIP) and TB Ultimate (automatic migration within the TB app)/

Note to external contributors: make sure to sign our Contribution License Agreement (CLA) for Blazor UI first:

https://forms.office.com/Pages/ResponsePage.aspx?id=Z2om2-DLJk2uGtBYH-A1NbWxVqugKN5DvVp8I-1AgOBURFBVSkwyMlA1TkFDVFdMNU1aM1o1UlZQOC4u
